### PR TITLE
feat: make typeorm migration no auto load and create end to end  tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+Dockerfile
+.gitignore
+README.md
+.vscodew
+dist

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ lerna-debug.log*
 .env.test.local
 .env.production.local
 .env.local
+.env.docker
 
 # temp directory
 .temp

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,16 @@
 {
-  "a-file-icon-vscode.activeIconPacks": ["nest", "rails"]
+  "a-file-icon-vscode.activeIconPacks": [
+    "angular",
+    "ngrx",
+    "nest",
+    "react",
+    "redux",
+    "recoil",
+    "vue",
+    "vuex",
+    "rails",
+    "phalcon",
+    "volt",
+    "none"
+  ]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.9'
+
+services:
+  db:
+    image: mysql:latest
+    container_name: mostaqem_db
+    environment:
+      MYSQL_ROOT_PASSWORD: 'db_password'
+      MYSQL_DATABASE: 'mostaqem_db'
+  api_v1:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - '3000:3000'
+    expose:
+      - '3000'
+    env_file:
+      - .env.docker
+    volumes:
+      - ./src:/app/src
+    links:
+      - db

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,13 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY . .
+
+RUN npm install -g pnpm
+
+RUN pnpm install
+
+EXPOSE 3000
+ 
+CMD [ "pnpm" , "run", "start:prod"]

--- a/jest-e2e.json
+++ b/jest-e2e.json
@@ -1,0 +1,12 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": "./",
+  "testRegex": ".*\\.e2e-spec\\.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^src/(.*)$": "<rootDir>/src/$1"
+  },
+  "testEnvironment": "node"
+}

--- a/migrations/1721758921061-init.ts
+++ b/migrations/1721758921061-init.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Init1721758921061 implements MigrationInterface {
+    name = 'Init1721758921061'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE \`reciter\` (\`id\` int NOT NULL AUTO_INCREMENT, \`name_english\` varchar(100) NOT NULL, \`name_arabic\` varchar(100) NOT NULL, \`image\` varchar(250) NULL, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`);
+        await queryRunner.query(`CREATE TABLE \`reciter_surah\` (\`reciter_id\` int NOT NULL, \`surah_id\` int NOT NULL, \`url\` varchar(255) NOT NULL, PRIMARY KEY (\`reciter_id\`, \`surah_id\`)) ENGINE=InnoDB`);
+        await queryRunner.query(`CREATE TABLE \`surah\` (\`id\` int NOT NULL AUTO_INCREMENT, \`name_arabic\` varchar(100) NOT NULL, \`name_complex\` varchar(100) NOT NULL, \`verses_count\` int NOT NULL, \`revelation_place\` varchar(30) NOT NULL, \`image\` varchar(250) NULL, INDEX \`IDX_SURAH\` (\`id\`, \`name_arabic\`, \`name_complex\`, \`verses_count\`, \`revelation_place\`, \`image\`), PRIMARY KEY (\`id\`)) ENGINE=InnoDB`);
+        await queryRunner.query(`CREATE TABLE \`verse\` (\`id\` int NOT NULL AUTO_INCREMENT, \`vers\` text NOT NULL, \`verse_number\` int NOT NULL, \`vers_lang\` varchar(3) NOT NULL, \`surah_id\` int NOT NULL, INDEX \`idx_surah_id\` (\`surah_id\`), INDEX \`SURAH_VERSE_UNIQUE\` (\`surah_id\`, \`verse_number\`), PRIMARY KEY (\`id\`)) ENGINE=InnoDB`);
+        await queryRunner.query(`ALTER TABLE \`reciter_surah\` ADD CONSTRAINT \`FK_c083c2e64bff5563b0940b6ae9a\` FOREIGN KEY (\`reciter_id\`) REFERENCES \`reciter\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`reciter_surah\` ADD CONSTRAINT \`FK_faeb6bf0be06de7f316921c0068\` FOREIGN KEY (\`surah_id\`) REFERENCES \`surah\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`verse\` ADD CONSTRAINT \`FK_7da0f9ffbbe4ea8116f2f36610a\` FOREIGN KEY (\`surah_id\`) REFERENCES \`surah\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`verse\` DROP FOREIGN KEY \`FK_7da0f9ffbbe4ea8116f2f36610a\``);
+        await queryRunner.query(`ALTER TABLE \`reciter_surah\` DROP FOREIGN KEY \`FK_faeb6bf0be06de7f316921c0068\``);
+        await queryRunner.query(`ALTER TABLE \`reciter_surah\` DROP FOREIGN KEY \`FK_c083c2e64bff5563b0940b6ae9a\``);
+        await queryRunner.query(`DROP INDEX \`SURAH_VERSE_UNIQUE\` ON \`verse\``);
+        await queryRunner.query(`DROP INDEX \`idx_surah_id\` ON \`verse\``);
+        await queryRunner.query(`DROP TABLE \`verse\``);
+        await queryRunner.query(`DROP INDEX \`IDX_SURAH\` ON \`surah\``);
+        await queryRunner.query(`DROP TABLE \`surah\``);
+        await queryRunner.query(`DROP TABLE \`reciter_surah\``);
+        await queryRunner.query(`DROP TABLE \`reciter\``);
+    }
+
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "test:e2e": "jest --config ./jest-e2e.json --detectOpenHandles",
     "typeorm": "ts-node --require tsconfig-paths/register ./node_modules/typeorm/cli",
     "typeorm:generate-migration": "npm run typeorm -- -d ./typeorm.config.ts migration:generate ./migrations/$npm_config_name", 
     "typeorm:migrate": "npm run typeorm -- -d ./typeorm.config.ts migration:run"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "typeorm": "ts-node --require tsconfig-paths/register ./node_modules/typeorm/cli",
+    "typeorm:generate-migration": "npm run typeorm -- -d ./typeorm.config.ts migration:generate ./migrations/$npm_config_name", 
+    "typeorm:migrate": "npm run typeorm -- -d ./typeorm.config.ts migration:run"
   },
   "dependencies": {
     "@nestjs/cache-manager": "^2.2.2",
@@ -33,6 +36,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "cookie-parser": "^1.4.6",
+    "dotenv": "^16.4.5",
     "mysql2": "^3.10.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       cookie-parser:
         specifier: ^1.4.6
         version: 1.4.6
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.4.5
       mysql2:
         specifier: ^3.10.3
         version: 3.10.3

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -28,7 +28,7 @@ import { CacheModule } from '@nestjs/cache-manager';
       password: process.env.DB_PASSWORD,
       database: process.env.DB_NAME,
       autoLoadEntities: true,
-      synchronize: true,
+      synchronize: process.env.NODE_ENV == 'development',
       connectTimeout: 60000,
       retryDelay: 6000,
     }),

--- a/test/audio.e2e-spec.ts
+++ b/test/audio.e2e-spec.ts
@@ -1,0 +1,32 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from './../src/app.module';
+import { isURL } from 'class-validator';
+
+describe('Audio E2E TESTS', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  it('should get reciter surah audio', () => {
+    const surah_id = 1;
+    const reciter_id = 1;
+
+    return request(app.getHttpServer())
+      .get(`/audio?surah_id=${surah_id}&reciter_id=${reciter_id}`)
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.surah_id).toBe(surah_id);
+        expect(res.body.reciter_id).toBe(reciter_id);
+        expect(isURL(res.body.url)).toBe(true);
+      });
+  });
+});

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -1,9 +1,0 @@
-{
-  "moduleFileExtensions": ["js", "json", "ts"],
-  "rootDir": ".",
-  "testEnvironment": "node",
-  "testRegex": ".e2e-spec.ts$",
-  "transform": {
-    "^.+\\.(t|j)s$": "ts-jest"
-  }
-}

--- a/test/reciter.e2e-spec.ts
+++ b/test/reciter.e2e-spec.ts
@@ -1,0 +1,45 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from './../src/app.module';
+
+describe('Reciter E2E TESTS', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  it('should get all reciters', () => {
+    return request(app.getHttpServer()).get('/reciter').expect(200);
+  });
+
+  it('should get reciter by id', () => {
+    return request(app.getHttpServer()).get('/reciter/1').expect(200);
+  });
+
+  it('should return 404 if reciter not found by id', () => {
+    return request(app.getHttpServer()).get('/reciter/99999').expect(404);
+  });
+
+  describe('adding image section', () => {
+    it('should add an image to a reciter', () => {
+      return request(app.getHttpServer())
+        .patch('/reciter/1')
+        .send({ image: 'image-url' })
+        .expect(200);
+    });
+
+    it('should return 404 if reciter not found by id', () => {
+      return request(app.getHttpServer())
+        .patch('/reciter/99999')
+        .send({ image: 'image-url' })
+        .expect(404);
+    });
+  });
+});

--- a/test/surah.e2e-spec.ts
+++ b/test/surah.e2e-spec.ts
@@ -1,0 +1,70 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from './../src/app.module';
+
+describe('Surah E2E TESTS', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  it('should get list of all surah', () => {
+    return request(app.getHttpServer())
+      .get('/surah')
+      .expect(200)
+      .expect((res) => {
+        expect(res.body).toHaveLength(114);
+        expect(res.body[0]).toMatchObject({
+          id: 1,
+          name_arabic: 'الفاتحة',
+          name_complex: 'Al-Fatihah',
+          revelation_place: 'meccan',
+          verses_count: 7,
+          image: 'image-url',
+        });
+      });
+  });
+
+  it('should get a surah by id', () => {
+    return request(app.getHttpServer())
+      .get('/surah/1')
+      .expect(200)
+      .expect((res) => {
+        expect(res.body).toMatchObject({
+          id: 1,
+          name_arabic: 'الفاتحة',
+          name_complex: 'Al-Fatihah',
+          revelation_place: 'meccan',
+          verses_count: 7,
+          image: 'image-url',
+        });
+      });
+  });
+
+  describe('adding image section', () => {
+    it('should add an image to a surah', () => {
+      return request(app.getHttpServer())
+        .patch('/surah/1')
+        .send({ image: 'image-url' })
+        .expect(200);
+    });
+
+    it('should return 404 if surah not found by id', () => {
+      return request(app.getHttpServer())
+        .patch('/surah/150')
+        .send({ image: 'image-url' })
+        .expect(404);
+    });
+  });
+
+  it('should return  404 if surah not found by id', () => {
+    return request(app.getHttpServer()).get('/surah/150').expect(404);
+  });
+});

--- a/test/verse.e2e-spec.ts
+++ b/test/verse.e2e-spec.ts
@@ -3,7 +3,7 @@ import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from './../src/app.module';
 
-describe('AppController (e2e)', () => {
+describe('Verse E2E TESTS', () => {
   let app: INestApplication;
 
   beforeEach(async () => {
@@ -15,10 +15,19 @@ describe('AppController (e2e)', () => {
     await app.init();
   });
 
-  it('/ (GET)', () => {
+  it('should get surah verses', () => {
     return request(app.getHttpServer())
-      .get('/')
+      .get('/verse/surah?surah_id=1')
       .expect(200)
-      .expect('Hello World!');
+      .expect((res) => {
+        expect(res.body.verses).toHaveLength(7);
+        expect(res.body.verses[0]).toMatchObject({
+          id: 1,
+          vers: 'بِسۡمِ ٱللَّهِ ٱلرَّحۡمَٰنِ ٱلرَّحِيمِ',
+          verse_number: 1,
+          vers_lang: 'ar',
+          surah_id: 1,
+        });
+      });
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
     "forceConsistentCasingInFileNames": false,
     "noFallthroughCasesInSwitch": false
   },
-  "include": ["src/**/*", "test", "seed.ts"]
+  "include": ["src/**/*", "test", "seed.ts","typeorm.config.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
     "forceConsistentCasingInFileNames": false,
     "noFallthroughCasesInSwitch": false
   },
-  "include": ["src/**/*", "test", "seed.ts","typeorm.config.ts"]
+  "include": ["src/**/*", "test", "seed.ts"]
 }

--- a/typeorm.config.ts
+++ b/typeorm.config.ts
@@ -1,0 +1,15 @@
+import { DataSource } from 'typeorm';
+import { config } from 'dotenv';
+config({ path: '.env.docker' });
+
+export default new DataSource({
+  type: 'mysql',
+  host: process.env.DB_HOST,
+  port: Number(process.env.DB_PORT),
+  username: process.env.DB_USERNAME,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+  entities: ['dist/**/*.entity{.ts,.js}', 'src/**/*.entity{.ts,.js}'],
+  migrations: ['migrations/**'],
+  ssl: process.env.NODE_ENV == 'production' ? true : false,
+});


### PR DESCRIPTION
# changes 
 - make production migration without sync TypeOrm to be in the best practice
 -  add e2e tests 