### PR TITLE
52 recommend surah alkahaf for every fridays

### DIFF
--- a/src/audio/audio.controller.spec.ts
+++ b/src/audio/audio.controller.spec.ts
@@ -3,6 +3,8 @@ import { AudioController } from './audio.controller';
 import { AudioService } from './audio.service';
 import { CreateAudioDto } from './dto/create-audio.dto';
 import { FilterAudioDto } from './dto/filter-audio.dto';
+import { FilterAudioLrcDto } from './dto/filter-lrc.dto';
+import { RandomDto } from './dto/random.dto';
 import { TilawaSurah } from 'src/surah/entities/tilawa-surah.entity';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 
@@ -19,6 +21,8 @@ describe('AudioController', () => {
           useValue: {
             create: jest.fn(),
             getAudio: jest.fn(),
+            getAudioLrc: jest.fn(),
+            getRandomAudio: jest.fn(),
           },
         },
         {
@@ -35,6 +39,10 @@ describe('AudioController', () => {
 
     controller = module.get<AudioController>(AudioController);
     service = module.get<AudioService>(AudioService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {
@@ -74,6 +82,56 @@ describe('AudioController', () => {
       expect(result).toEqual(expectedResult);
       expect(service.create).toHaveBeenCalledWith(createAudioDto);
     });
+
+    it('should handle creation with different URL formats', async () => {
+      const createAudioDto: CreateAudioDto = {
+        surah_id: 2,
+        tilawa_id: 2,
+        url: 'https://cdn.example.com/quran/audio/002_001.mp3',
+      };
+      const expectedResult: Partial<TilawaSurah> & { reciter_id: number } = {
+        surah_id: 2,
+        tilawa_id: 2,
+        url: 'https://cdn.example.com/quran/audio/002_001.mp3',
+        tilawa: {
+          id: 2,
+          name: 'Test Tilawa 2',
+          name_english: 'Test Tilawa 2',
+          reciter_id: 2,
+          reciter: {},
+          tilawaSurah: [],
+        } as any,
+        surah: {} as any,
+        reciter_id: 2,
+      };
+
+      jest.spyOn(service, 'create').mockResolvedValue({
+        ...expectedResult,
+        reciter_id: 2,
+      } as TilawaSurah & { reciter_id: number });
+
+      const result = await controller.create(createAudioDto);
+
+      expect(result).toEqual(expectedResult);
+      expect(service.create).toHaveBeenCalledWith(createAudioDto);
+    });
+
+    it('should handle service errors during creation', async () => {
+      const createAudioDto: CreateAudioDto = {
+        surah_id: 1,
+        tilawa_id: 1,
+        url: 'https://example.com/audio.mp3',
+      };
+
+      jest
+        .spyOn(service, 'create')
+        .mockRejectedValue(new Error('Creation failed'));
+
+      await expect(controller.create(createAudioDto)).rejects.toThrow(
+        'Creation failed',
+      );
+      expect(service.create).toHaveBeenCalledWith(createAudioDto);
+    });
   });
 
   describe('get', () => {
@@ -101,6 +159,286 @@ describe('AudioController', () => {
 
       expect(result).toEqual(expectedResult);
       expect(service.getAudio).toHaveBeenCalledWith(filterAudioDto);
+    });
+
+    it('should get audio by filter with tilawa_id', async () => {
+      const filterAudioDto: FilterAudioDto = {
+        surah_id: 1,
+        tilawa_id: 1,
+        reciter_id: undefined,
+      };
+      const expectedResult = {
+        tilawa_id: 1,
+        url: 'https://example2.com/audio.mp3',
+        surah: {
+          name_arabic: 'الفاتحة',
+          name_complex: 'Al-Fatiha',
+        },
+        tilawa: {
+          reciter: {
+            name_arabic: 'عبدالباسط عبدالصمد',
+            name_english: 'Abdul Basit Abdul Samad',
+          },
+        },
+      };
+
+      jest.spyOn(service, 'getAudio').mockResolvedValue(expectedResult as any);
+
+      const result = await controller.get(filterAudioDto);
+
+      expect(result).toEqual(expectedResult);
+      expect(service.getAudio).toHaveBeenCalledWith(filterAudioDto);
+    });
+
+    it('should handle service errors', async () => {
+      const filterAudioDto: FilterAudioDto = {
+        surah_id: 1,
+        reciter_id: undefined,
+      };
+
+      jest
+        .spyOn(service, 'getAudio')
+        .mockRejectedValue(new Error('Service error'));
+
+      await expect(controller.get(filterAudioDto)).rejects.toThrow(
+        'Service error',
+      );
+      expect(service.getAudio).toHaveBeenCalledWith(filterAudioDto);
+    });
+  });
+
+  describe('getLrc', () => {
+    it('should get LRC content for audio', async () => {
+      const filterAudioLrcDto: FilterAudioLrcDto = {
+        surah_id: 1,
+        tilawa_id: 1,
+      };
+      const expectedResult = {
+        lrc_content:
+          '[00:00.00] بِسۡمِ/[00:01.04] ٱللَّهِ/[00:01.66] ٱلرَّحۡمَٰنِ/[00:02.61] ٱلرَّحِيمِ',
+      };
+
+      jest
+        .spyOn(service, 'getAudioLrc')
+        .mockResolvedValue(expectedResult as any);
+
+      const result = await controller.getLrc(filterAudioLrcDto);
+
+      expect(result).toEqual(expectedResult);
+      expect(service.getAudioLrc).toHaveBeenCalledWith(filterAudioLrcDto);
+    });
+
+    it('should handle when no LRC content is found', async () => {
+      const filterAudioLrcDto: FilterAudioLrcDto = {
+        surah_id: 999,
+        tilawa_id: 999,
+      };
+
+      jest.spyOn(service, 'getAudioLrc').mockResolvedValue(null);
+
+      const result = await controller.getLrc(filterAudioLrcDto);
+
+      expect(result).toBeNull();
+      expect(service.getAudioLrc).toHaveBeenCalledWith(filterAudioLrcDto);
+    });
+
+    it('should get LRC content for different surahs', async () => {
+      const filterAudioLrcDto: FilterAudioLrcDto = {
+        surah_id: 18, // Surah Al-Kahf
+        tilawa_id: 1,
+      };
+      const expectedResult = {
+        lrc_content:
+          '[00:00.00] ٱلۡحَمۡدُ/[00:01.04] لِلَّهِ/[00:01.66] ٱلَّذِیۤ/[00:02.61] أَنزَلَ',
+      };
+
+      jest
+        .spyOn(service, 'getAudioLrc')
+        .mockResolvedValue(expectedResult as any);
+
+      const result = await controller.getLrc(filterAudioLrcDto);
+
+      expect(result).toEqual(expectedResult);
+      expect(service.getAudioLrc).toHaveBeenCalledWith(filterAudioLrcDto);
+    });
+
+    it('should handle service errors in getLrc', async () => {
+      const filterAudioLrcDto: FilterAudioLrcDto = {
+        surah_id: 1,
+        tilawa_id: 1,
+      };
+
+      jest
+        .spyOn(service, 'getAudioLrc')
+        .mockRejectedValue(new Error('LRC service error'));
+
+      await expect(controller.getLrc(filterAudioLrcDto)).rejects.toThrow(
+        'LRC service error',
+      );
+      expect(service.getAudioLrc).toHaveBeenCalledWith(filterAudioLrcDto);
+    });
+  });
+
+  describe('getRandom', () => {
+    it('should get random audio with default parameters', async () => {
+      const randomDto: RandomDto = {
+        limit: 5,
+      };
+      const expectedResult = [
+        {
+          tilawa_id: 1,
+          url: 'https://example1.com/audio.mp3',
+          surah: { name_arabic: 'الفاتحة' },
+          reciter: { name_arabic: 'عبدالرحمن السديس' },
+        },
+        {
+          tilawa_id: 2,
+          url: 'https://example2.com/audio.mp3',
+          surah: { name_arabic: 'البقرة' },
+          reciter: { name_arabic: 'عبدالباسط' },
+        },
+      ];
+
+      jest
+        .spyOn(service, 'getRandomAudio')
+        .mockResolvedValue(expectedResult as any);
+
+      const result = await controller.getRandom(randomDto);
+
+      expect(result).toEqual(expectedResult);
+      expect(service.getRandomAudio).toHaveBeenCalledWith(
+        randomDto.limit,
+        randomDto.reciter_id,
+        randomDto.timeZone,
+      );
+    });
+
+    it('should get random audio with reciter filter', async () => {
+      const randomDto: RandomDto = {
+        limit: 3,
+        reciter_id: 1,
+        timeZone: 'UTC',
+      };
+      const expectedResult = [
+        {
+          tilawa_id: 1,
+          url: 'https://example1.com/audio.mp3',
+          surah: { name_arabic: 'الفاتحة' },
+          reciter: { name_arabic: 'عبدالرحمن السديس' },
+        },
+      ];
+
+      jest
+        .spyOn(service, 'getRandomAudio')
+        .mockResolvedValue(expectedResult as any);
+
+      const result = await controller.getRandom(randomDto);
+
+      expect(result).toEqual(expectedResult);
+      expect(service.getRandomAudio).toHaveBeenCalledWith(
+        randomDto.limit,
+        randomDto.reciter_id,
+        randomDto.timeZone,
+      );
+    });
+
+    it('should get random audio with Friday special case', async () => {
+      const randomDto: RandomDto = {
+        limit: 5,
+        timeZone: 'UTC',
+      };
+      const expectedResult = [
+        {
+          tilawa_id: 1,
+          url: 'https://example1.com/audio.mp3',
+          surah: { name_arabic: 'الكهف', surah_id: 18 }, // Surah Al-Kahf
+          reciter: { name_arabic: 'عبدالرحمن السديس' },
+        },
+        {
+          tilawa_id: 2,
+          url: 'https://example2.com/audio.mp3',
+          surah: { name_arabic: 'الفاتحة' },
+          reciter: { name_arabic: 'عبدالباسط' },
+        },
+      ];
+
+      jest
+        .spyOn(service, 'getRandomAudio')
+        .mockResolvedValue(expectedResult as any);
+
+      const result = await controller.getRandom(randomDto);
+
+      expect(result).toEqual(expectedResult);
+      expect(service.getRandomAudio).toHaveBeenCalledWith(
+        randomDto.limit,
+        randomDto.reciter_id,
+        randomDto.timeZone,
+      );
+    });
+
+    it('should handle empty result from service', async () => {
+      const randomDto: RandomDto = {
+        limit: 5,
+      };
+
+      jest.spyOn(service, 'getRandomAudio').mockResolvedValue([]);
+
+      const result = await controller.getRandom(randomDto);
+
+      expect(result).toEqual([]);
+      expect(service.getRandomAudio).toHaveBeenCalledWith(
+        randomDto.limit,
+        randomDto.reciter_id,
+        randomDto.timeZone,
+      );
+    });
+
+    it('should handle service errors in getRandom', async () => {
+      const randomDto: RandomDto = {
+        limit: 5,
+      };
+
+      jest
+        .spyOn(service, 'getRandomAudio')
+        .mockRejectedValue(new Error('Random audio service error'));
+
+      await expect(controller.getRandom(randomDto)).rejects.toThrow(
+        'Random audio service error',
+      );
+      expect(service.getRandomAudio).toHaveBeenCalledWith(
+        randomDto.limit,
+        randomDto.reciter_id,
+        randomDto.timeZone,
+      );
+    });
+
+    it('should handle limit boundary cases', async () => {
+      const randomDto: RandomDto = {
+        limit: 1,
+        reciter_id: 1,
+      };
+      const expectedResult = [
+        {
+          tilawa_id: 1,
+          url: 'https://example1.com/audio.mp3',
+          surah: { name_arabic: 'الفاتحة' },
+          reciter: { name_arabic: 'عبدالرحمن السديس' },
+        },
+      ];
+
+      jest
+        .spyOn(service, 'getRandomAudio')
+        .mockResolvedValue(expectedResult as any);
+
+      const result = await controller.getRandom(randomDto);
+
+      expect(result).toEqual(expectedResult);
+      expect(result).toHaveLength(1);
+      expect(service.getRandomAudio).toHaveBeenCalledWith(
+        randomDto.limit,
+        randomDto.reciter_id,
+        randomDto.timeZone,
+      );
     });
   });
 });

--- a/src/audio/audio.controller.ts
+++ b/src/audio/audio.controller.ts
@@ -29,6 +29,7 @@ export class AudioController {
     return this.audioService.getRandomAudio(
       randomDto.limit,
       randomDto.reciter_id,
+      randomDto.timeZone,
     );
   }
 }

--- a/src/audio/audio.service.ts
+++ b/src/audio/audio.service.ts
@@ -70,7 +70,6 @@ export class AudioService {
       ? new Date(new Date().toLocaleString('en-US', { timeZone }))
       : new Date();
 
-    console.log('Today:', today);
     const isFriday = today.getDay() === 5;
 
     if (isFriday) {

--- a/src/audio/audio.service.ts
+++ b/src/audio/audio.service.ts
@@ -1,7 +1,7 @@
 import { ConflictException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { TilawaSurah } from 'src/surah/entities/tilawa-surah.entity';
-import { In, Repository } from 'typeorm';
+import { In, Not, Repository } from 'typeorm';
 import { CreateAudioDto } from './dto/create-audio.dto';
 import { FilterAudioDto } from './dto/filter-audio.dto';
 import { ReciterService } from 'src/reciter/reciter.service';
@@ -60,9 +60,67 @@ export class AudioService {
     });
   }
 
-  async getRandomAudio(limit: number, reciter_id: number) {
+  async getRandomAudio(limit: number, reciter_id?: number, timeZone?: string) {
     if (limit < 1) {
       throw new Error('Limit must be greater than 0');
+    }
+
+    // Check if today is Friday (5 in JavaScript Date)
+    const today = timeZone
+      ? new Date(new Date().toLocaleString('en-US', { timeZone }))
+      : new Date();
+
+    console.log('Today:', today);
+    const isFriday = today.getDay() === 5;
+
+    if (isFriday) {
+      // On Friday, get Surah Al-Kahf (surah_id: 18) from any reciter
+      const fridayAudio = await this.tilawaSurahRepo.find({
+        select: ['tilawa_id', 'url'],
+        where: {
+          surah_id: 18, // Surah Al-Kahf
+        },
+        relations: {
+          surah: true,
+          tilawa: {
+            reciter: true,
+          },
+        },
+      });
+
+      if (fridayAudio?.length) {
+        // Shuffle Surah Al-Kahf recitations
+        for (let i = fridayAudio.length - 1; i > 0; i--) {
+          const j = Math.floor(Math.random() * (i + 1));
+          [fridayAudio[i], fridayAudio[j]] = [fridayAudio[j], fridayAudio[i]];
+        }
+
+        const randomTilawa =
+          await this.reciterService.getRandomTilawa(reciter_id);
+
+        const otherAudio = await this.tilawaSurahRepo.find({
+          select: ['tilawa_id', 'url'],
+          where: {
+            tilawa_id: In(randomTilawa.map((tilawa) => tilawa.id)),
+            surah_id: Not(18),
+          },
+          relations: {
+            surah: true,
+            tilawa: {
+              reciter: true,
+            },
+          },
+        });
+
+        // Shuffle other audio
+        for (let i = otherAudio.length - 1; i > 0; i--) {
+          const j = Math.floor(Math.random() * (i + 1));
+          [otherAudio[i], otherAudio[j]] = [otherAudio[j], otherAudio[i]];
+        }
+
+        // Return Surah Al-Kahf first, then other random audio
+        return [fridayAudio[0], ...otherAudio.slice(0, limit - 1)];
+      }
     }
 
     const randomTilawa = await this.reciterService.getRandomTilawa(reciter_id);
@@ -89,7 +147,6 @@ export class AudioService {
       const j = Math.floor(Math.random() * (i + 1));
       [audioRecords[i], audioRecords[j]] = [audioRecords[j], audioRecords[i]];
     }
-
     return audioRecords.slice(0, Math.min(limit, audioRecords.length));
   }
 }

--- a/src/audio/dto/random.dto.ts
+++ b/src/audio/dto/random.dto.ts
@@ -1,5 +1,5 @@
 import { Transform } from 'class-transformer';
-import { IsNumber, IsOptional, IsPositive } from 'class-validator';
+import { IsNumber, IsOptional, IsPositive, IsTimeZone } from 'class-validator';
 
 export class RandomDto {
   @IsNumber()
@@ -12,4 +12,8 @@ export class RandomDto {
   @Transform(({ value }) => parseInt(value))
   @IsOptional()
   reciter_id?: number;
+
+  @IsOptional()
+  @IsTimeZone()
+  timeZone?: string;
 }

--- a/src/reciter/reciter.service.ts
+++ b/src/reciter/reciter.service.ts
@@ -113,7 +113,7 @@ export class ReciterService {
     return tilawa;
   }
 
-  async getRandomTilawa(reciterId: number) {
+  async getRandomTilawa(reciterId?: number) {
     const tilawa = await this.tilawaRepository.find({
       where: {
         reciter_id: reciterId || In([1, 2, 3, 4, 14, 6, 13, 15, 18]),


### PR DESCRIPTION
This pull request introduces several enhancements and test cases for the `AudioController` and `AudioService` in the application. The key updates include adding new functionality for fetching random audio with timezone and Friday-specific logic, extending test coverage for various scenarios, and updating DTOs and services to support these changes.

### Enhancements to `AudioService` functionality:
* Implemented Friday-specific logic in `getRandomAudio` to prioritize Surah Al-Kahf (surah_id: 18) when the current day is Friday, and added support for a `timeZone` parameter to determine the current day. [[1]](diffhunk://#diff-a49c88a5cf25c7157b27f3fe9fbfc70fa3efd7cccc13d627a80e6cef36ae575eL63-R124) [[2]](diffhunk://#diff-a49c88a5cf25c7157b27f3fe9fbfc70fa3efd7cccc13d627a80e6cef36ae575eL92)
* Updated `getRandomAudio` to allow optional `reciter_id` and added shuffling logic for both Surah Al-Kahf and other audio records. [[1]](diffhunk://#diff-a49c88a5cf25c7157b27f3fe9fbfc70fa3efd7cccc13d627a80e6cef36ae575eL63-R124) [[2]](diffhunk://#diff-a49c88a5cf25c7157b27f3fe9fbfc70fa3efd7cccc13d627a80e6cef36ae575eL92)
* Modified `ReciterService` to support fetching random Tilawa records without requiring a specific `reciter_id`.

### Updates to DTOs:
* Added a `timeZone` field to `RandomDto` with validation using `IsTimeZone` to support timezone-aware operations. [[1]](diffhunk://#diff-740c05a8e5f77fc50accee1d7440ec332223fca5992ffcfb9ace04b8edd877bcL2-R2) [[2]](diffhunk://#diff-740c05a8e5f77fc50accee1d7440ec332223fca5992ffcfb9ace04b8edd877bcR15-R18)

### Test case improvements:
* Added comprehensive test cases in `AudioController` for:
  - Creating audio with different URL formats and handling service errors.
  - Fetching audio by filter with `tilawa_id` and handling service errors.
  - Fetching LRC content with various scenarios, including errors and different surahs.
  - Fetching random audio with default parameters, reciter filters, Friday-specific logic, and error handling.
* Introduced `jest.clearAllMocks()` in `afterEach` to ensure test isolation.

### Minor updates:
* Added imports for new DTOs (`FilterAudioLrcDto` and `RandomDto`) in `AudioController` tests.
* Updated `AudioController` to pass the `timeZone` parameter to the `getRandomAudio` method.
* Added `Not` import from TypeORM for filtering logic.